### PR TITLE
Adds extract only ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,23 @@ narp -h
 
 ```sh
 # extract + merge pots + upload pot
-node push --password MY_TRANSIFEX_PASS
+narp push --password MY_TRANSIFEX_PASS
 ```
 
 ```sh
 # download po's + convert to json + write to file
-node pull --password MY_TRANSIFEX_PASS
+narp pull --password MY_TRANSIFEX_PASS
 ```
 
 `--password` is also available as `-p`.
+
+```sh
+# extract messages to stdout (no password required)
+narp extract [./path/to/comps]
+
+Optionally put a path as arg 2 to just extract from the folder.
+Protip, pipe to file if you want to use it.
+```
 
 ### Using the API
 
@@ -83,20 +91,20 @@ The defaults are:
     "resource": null,
     "sourceLang": "en"
   },
-  
+
   // Configs that are passed to react-gettext-parser
   "extract": {
-  
+
     // A glob string (npmjs.com/glob) that matches all source files
     // that may contain translatable strings.
     "source": null,
-    
+
     // These two are passed directly to react-gettext-parser,
     // see the react-gettext-parser readme
     "componentPropsMap": { /* react-gettext-parser defaults */ },
     "funcArgumentsMap": { /* react-gettext-parser defaults */ }
   },
-  
+
   // Where to put all the translations
   "output": "messages.json"
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -56,3 +56,7 @@ if (args._[0] === 'push') {
     api.push(buildOptions(args.password, args.verbose));
   }
 }
+
+if (args._[0] === 'extract') {
+  api.extract(buildOptions(null, args.verbose), args._[1]);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -145,4 +145,26 @@ const push = (configs = {}) => {
   });
 };
 
-export { pull, push };
+const extract = (configs = {}, inputSource = '') => {
+  feedback.begin('extraction');
+
+  // extract strings from source => extract
+  const conf = extend(getConfig(), configs);
+  const rant = feedback.ranter(true);
+  const source = inputSource.length > 0
+                 ? [`${inputSource}/**/\{*.js,*.jsx\}`]
+                 : conf.extract.source;
+
+  feedback.step('Extracting messages from source code...');
+  const messages = extractMessagesFromGlob(source);
+
+  messages.forEach(msg => {
+    const { reference } = msg.comments;
+    const refs = reference.map(r => inputSource.length ? r.replace(inputSource, '') : r);
+    rant(`${refs.join(', ')} -> ${msg.msgid}`);
+  });
+
+  feedback.finish('Extracted all messages for you.');
+};
+
+export { pull, push, extract };


### PR DESCRIPTION
Sometimes you just want to extract what should be translated. This just extracts and then prints references -> msgid.

Convenient when you just want see whats up or when you’re not using Transifex at the moment.