### PR TITLE
Supports react-gettext-parser's trimming options

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,13 @@ This is the shape of narp's configuration. It can be provided as an object to th
     // that may contain translatable strings.
     "source": null,
 
-    // These two are passed directly to react-gettext-parser,
-    // see the react-gettext-parser readme
+    // The rest of the `extract` configs are passed directly to
+    // react-gettext-parser, see the react-gettext-parser readme.
     "componentPropsMap": { /* react-gettext-parser defaults */ },
-    "funcArgumentsMap": { /* react-gettext-parser defaults */ }
+    "funcArgumentsMap": { /* react-gettext-parser defaults */ },
+    "trim": false,
+    "trimLines": false,
+    "trimNewlines": false,
   },
 
   // Where to put all the translations

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "mkdirp": "^0.5.1",
     "pot-merge": "^2.1.0",
     "qs": "^6.5.0",
-    "react-gettext-parser": "^1.0.0",
+    "react-gettext-parser": "^1.4.0",
     "read": "^1.0.7",
     "string-to-stream": "^1.1.0",
     "yargs": "^4.6.0"

--- a/src/confighelpers.js
+++ b/src/confighelpers.js
@@ -8,6 +8,9 @@ const defaultConfig = {
   extract: {
     componentPropsMap: { ...GETTEXT_COMPONENT_PROPS_MAP },
     funcArgumentsMap: { ...GETTEXT_FUNC_ARGS_MAP },
+    trim: false,
+    trimLines: false,
+    trimNewlines: false,
   },
   merge: {},
   output: 'messages.json',

--- a/src/confighelpers.js
+++ b/src/confighelpers.js
@@ -6,8 +6,8 @@ import extend from 'deep-extend';
 const defaultConfig = {
   vendor: {},
   extract: {
-    componentPropsMap: GETTEXT_COMPONENT_PROPS_MAP,
-    funcArgumentsMap: GETTEXT_FUNC_ARGS_MAP,
+    componentPropsMap: { ...GETTEXT_COMPONENT_PROPS_MAP },
+    funcArgumentsMap: { ...GETTEXT_FUNC_ARGS_MAP },
   },
   merge: {},
   output: 'messages.json',

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,8 @@ const push = (configs = {}) => {
   vendor.assertCredentials(credentials);
 
   feedback.step('Extracting messages from source code...');
-  const messages = extractMessagesFromGlob(conf.extract.source);
+  const { source, ...rgpOptions } = conf.extract;
+  const messages = extractMessagesFromGlob(source, rgpOptions);
   const pot = toPot(messages);
   feedback.rant('Extracted pot:', pot);
 


### PR DESCRIPTION
It's now possible to specify the `trim`, `trimLines` and `trimNewlines` configs in `.narprc`.

If you fancy an example of the mighty evil of mutability, https://github.com/laget-se/narp/commit/3e853d4f9a287c372c545d175dadb8130c2338fb is a treat.