### PR TITLE
 Adds a `--fresh` argument to the push command

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "parser": "babel-eslint",
   "extends": "lagetse",
   "rules": {
     "no-console": 0,

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ narp -h
 
 ```sh
 # extract + merge pots + upload pot
-narp push [<credentials>]
+narp push [<credentials>] [--fresh]
 ```
 
 ```sh
@@ -156,6 +156,11 @@ This is the shape of narp's configuration. It can be provided as an object to th
 
   // Where to put all the translations
   "output": "messages.json",
+
+  // Whether the extracted strings should be uploaded without 
+  // being merged with the current upstream source strings, 
+  // thus replacing it
+  "fresh": false,
 
   // If true, will output debug information to the console
   "verbose": false

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel": "^6.5.2",
     "babel-cli": "^6.7.5",
     "babel-core": "^6.7.6",
+    "babel-eslint": "^8.2.5",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "eslint-config-lagetse": "^1.1.0",

--- a/src/confighelpers.js
+++ b/src/confighelpers.js
@@ -13,6 +13,7 @@ const defaultConfig = {
     trimNewlines: false,
   },
   merge: {},
+  fresh: false,
   output: 'messages.json',
 };
 


### PR DESCRIPTION
Sometimes you might want to do a fresh push, for instance when your 1000 strings limit on Poeditor has been reached. 😬

Adding `--fresh` (or passing `fresh: true`) to the `push` skips the merge with the current upstream pot and pushes the extract pot contents as is.

I made use of async/await, since the conditional merge resulted in a rather ugly `.then()` sauce.